### PR TITLE
Rewrite api routes to jutge-api and add more menus

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -12,10 +12,19 @@ import {
     SidebarMenuItem,
     SidebarMenuSub,
 } from '@/components/ui/sidebar'
-import { ChevronRight, Package, SquareChevronRight, SquareFunction, Type } from 'lucide-react'
+import {
+    ChevronRight,
+    Cog,
+    List,
+    Package,
+    SquareChevronRight,
+    SquareFunction,
+    Type,
+} from 'lucide-react'
 import Image from 'next/image'
 import * as React from 'react'
 import { NavUser } from './nav-user'
+import Link from 'next/link'
 
 type Item = {
     name: string
@@ -26,6 +35,12 @@ type Item = {
 }
 
 type Items = Item[]
+
+type ApiRawItem = {
+    name: string
+    href: string
+    icon?: string
+}
 
 type Module = any
 
@@ -97,6 +112,11 @@ export function AppSidebar({ ...props }: AppSidebarProps) {
         avatar: '/avatars/shadcn.jpg',
     }
 
+    const apiRaw = [
+        { name: 'Directory', href: '/api/dir' },
+        { name: 'Run', href: '/api/run' },
+    ]
+
     return (
         <Sidebar {...props}>
             <Header />
@@ -104,6 +124,7 @@ export function AppSidebar({ ...props }: AppSidebarProps) {
             <SidebarContent>
                 <Clients clients={clients} />
                 <Directory tree={tree} />
+                <ApiRaw apiRaw={apiRaw} />
             </SidebarContent>
 
             <SidebarFooter>
@@ -146,6 +167,28 @@ function Clients({ clients }: { clients: Items }) {
                             <SidebarMenuButton>
                                 <SquareChevronRight />
                                 {item.name}
+                            </SidebarMenuButton>
+                        </SidebarMenuItem>
+                    ))}
+                </SidebarMenu>
+            </SidebarGroupContent>
+        </SidebarGroup>
+    )
+}
+
+function ApiRaw({ apiRaw: items }: { apiRaw: ApiRawItem[] }) {
+    return (
+        <SidebarGroup>
+            <SidebarGroupLabel>API Raw</SidebarGroupLabel>
+            <SidebarGroupContent>
+                <SidebarMenu>
+                    {items.map((item, index) => (
+                        <SidebarMenuItem key={index}>
+                            <SidebarMenuButton>
+                                <Cog />
+                                <a target="_blank" href={item.href}>
+                                    {item.name}
+                                </a>
                             </SidebarMenuButton>
                         </SidebarMenuItem>
                     ))}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
 
-export default nextConfig;
+const nextConfig = {
+    async rewrites() {
+        return [
+            {
+                source: '/api/:path*',
+                destination: `http://localhost:8008/api/:path*`,
+            },
+        ]
+    },
+}
+
+export default nextConfig


### PR DESCRIPTION
It is so easy to redirect paths! Just see `next.config.mjs`.

A thing that remains to do is reorganize the ~/.jutge.yml configuration file and use it to set the correct ports.

I think it should be set like so:

```yaml
servers:
  api:
    protocol: 'http'
    host: 'localhost'
    port: 3000
  api-doc:
    protocol: 'http'
    host: 'localhost'
    port: 8008
```

jutge-api can run at any local port, but in production api-doc should run at 8008 because this gives raise to https://api.jutge.org